### PR TITLE
optionally pass credentials in request body

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -154,6 +154,11 @@ impl<P: Provider> Client<P> {
             body_pairs.push(("redirect_uri", redirect_uri));
         }
 
+        if P::credentials_in_body() {
+            body_pairs.push(("client_id", &self.client_id));
+            body_pairs.push(("client_secret", &self.client_secret));
+        }
+
         let json = try!(self.post_token(body_pairs));
         let token = try!(P::Token::from_response(&json));
         Ok(token)

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -19,6 +19,13 @@ pub trait Provider {
     ///
     /// See [RFC 6749, section 3.2](http://tools.ietf.org/html/rfc6749#section-3.2).
     fn token_uri() -> &'static str;
+
+    /// Provider supports credentials via request body only.
+    /// Although not recommended by the RFC, some implementations accept client_id
+    /// and client_secret as a part of request only (most notable offender is vk.com).
+    ///
+    /// See [RFC 6749, section 2.3.1](http://tools.ietf.org/html/rfc6749#section-2.3.1).
+    fn credentials_in_body() -> bool { false }
 }
 
 /// Google OAuth 2.0 provider.


### PR DESCRIPTION
Some OAuth2 implementors require client_id/client_secret in the request body
(see for details https://vk.com/dev/auth_sites).

While this is not encouraged by the RFCs, it is [not strictly forbidden either](http://tools.ietf.org/html/rfc6749#section-2.3.1), so it should be implemented in the code as well.

Here I propose a new method in `Provider` trait to configure this behavior.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/programble/inth-oauth2/3)
<!-- Reviewable:end -->
