### PR TITLE
Implement Serde Serialize and Deserialize for tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 chrono = "0.2.17"
 hyper = "0.7.0"
 rustc-serialize = "0.3.16"
+serde = "0.6.1"
 url = "0.5.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ serde = "0.6.1"
 url = "0.5.0"
 
 [dev-dependencies]
+serde_json = "0.6.0"
 yup-hyper-mock = "1.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@
 extern crate chrono;
 extern crate hyper;
 extern crate rustc_serialize;
+extern crate serde;
 extern crate url;
 
 pub use token::{Token, Lifetime};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,8 @@
 //!
 //! ### Persisting tokens
 //!
-//! All token types implement `Encodable` and `Decodable` from `rustc_serialize`.
+//! All token types implement `Encodable` / `Decodable` from `rustc_serialize` and `Serialize` /
+//! `Deserialize` from `serde`.
 //!
 //! ```no_run
 //! # extern crate inth_oauth2;
@@ -120,6 +121,18 @@
 //! # let client = Client::<Google>::new(Default::default(), "", "", None);
 //! # let token = client.request_token("").unwrap();
 //! let json = json::encode(&token).unwrap();
+//! # }
+//! ```
+//!
+//! ```no_run
+//! # extern crate inth_oauth2;
+//! extern crate serde_json;
+//! # use inth_oauth2::Client;
+//! # use inth_oauth2::provider::Google;
+//! # fn main() {
+//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let token = client.request_token("").unwrap();
+//! let json = serde_json::to_string(&token).unwrap();
 //! # }
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,3 +149,6 @@ pub mod token;
 pub mod provider;
 pub mod error;
 pub mod client;
+
+#[cfg(test)]
+extern crate serde_json;

--- a/src/token/bearer.rs
+++ b/src/token/bearer.rs
@@ -157,6 +157,7 @@ impl de::Visitor for FieldVisitor {
 mod tests {
     use chrono::{UTC, Duration};
     use rustc_serialize::json::Json;
+    use serde_json;
 
     use client::response::{FromResponse, ParseError};
     use token::{Static, Expiring};
@@ -257,5 +258,17 @@ mod tests {
         assert_eq!("bbbbbbbb", expiring.refresh_token());
         assert!(expiring.expires() > &UTC::now());
         assert!(expiring.expires() <= &(UTC::now() + Duration::seconds(3600)));
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let original = Bearer {
+            access_token: String::from("foo"),
+            scope: Some(String::from("bar")),
+            lifetime: Static,
+        };
+        let serialized = serde_json::to_value(&original);
+        let deserialized = serde_json::from_value(serialized).unwrap();
+        assert_eq!(original, deserialized);
     }
 }

--- a/src/token/expiring.rs
+++ b/src/token/expiring.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, UTC, Duration, TimeZone};
 use rustc_serialize::json::Json;
 use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
+use serde::{ser, de};
 
 use super::Lifetime;
 use client::response::{FromResponse, ParseError, JsonHelper};
@@ -88,6 +90,91 @@ impl Encodable for Expiring {
 impl Decodable for Expiring {
     fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
         Serializable::decode(d).map(Into::into)
+    }
+}
+
+impl Serialize for Expiring {
+    fn serialize<S: Serializer>(&self, serializer: &mut S) -> Result<(), S::Error> {
+        serializer.visit_struct("Expiring", SerVisitor(self, 0))
+    }
+}
+
+struct SerVisitor<'a>(&'a Expiring, u8);
+impl<'a> ser::MapVisitor for SerVisitor<'a> {
+    fn visit<S: Serializer>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error> {
+        self.1 += 1;
+        match self.1 {
+            1 => serializer.visit_struct_elt("refresh_token", &self.0.refresh_token).map(Some),
+            2 => serializer.visit_struct_elt("expires", &self.0.expires.timestamp()).map(Some),
+            _ => Ok(None),
+        }
+    }
+
+    fn len(&self) -> Option<usize> { Some(2) }
+}
+
+impl Deserialize for Expiring {
+    fn deserialize<D: Deserializer>(deserializer: &mut D) -> Result<Self, D::Error> {
+        static FIELDS: &'static [&'static str] = &["refresh_token", "expires"];
+        deserializer.visit_struct("Expiring", FIELDS, DeVisitor)
+    }
+}
+
+struct DeVisitor;
+impl de::Visitor for DeVisitor {
+    type Value = Expiring;
+
+    fn visit_map<V: de::MapVisitor>(&mut self, mut visitor: V) -> Result<Expiring, V::Error> {
+        let mut refresh_token = None;
+        let mut expires = None;
+
+        loop {
+            match try!(visitor.visit_key()) {
+                Some(Field::RefreshToken) => refresh_token = Some(try!(visitor.visit_value())),
+                Some(Field::Expires) => expires = Some(try!(visitor.visit_value())),
+                None => break,
+            }
+        }
+
+        let refresh_token = match refresh_token {
+            Some(s) => s,
+            None => return visitor.missing_field("refresh_token"),
+        };
+        let expires = match expires {
+            Some(i) => UTC.timestamp(i, 0),
+            None => return visitor.missing_field("expires"),
+        };
+
+        try!(visitor.end());
+
+        Ok(Expiring {
+            refresh_token: refresh_token,
+            expires: expires,
+        })
+    }
+}
+
+enum Field {
+    RefreshToken,
+    Expires,
+}
+
+impl Deserialize for Field {
+    fn deserialize<D: Deserializer>(deserializer: &mut D) -> Result<Self, D::Error> {
+        deserializer.visit(FieldVisitor)
+    }
+}
+
+struct FieldVisitor;
+impl de::Visitor for FieldVisitor {
+    type Value = Field;
+
+    fn visit_str<E: de::Error>(&mut self, value: &str) -> Result<Field, E> {
+        match value {
+            "refresh_token" => Ok(Field::RefreshToken),
+            "expires" => Ok(Field::Expires),
+            _ => Err(de::Error::syntax("expected refresh_token or expires")),
+        }
     }
 }
 

--- a/src/token/expiring.rs
+++ b/src/token/expiring.rs
@@ -182,6 +182,7 @@ impl de::Visitor for FieldVisitor {
 mod tests {
     use chrono::{UTC, Duration, Timelike};
     use rustc_serialize::json::{self, Json};
+    use serde_json;
 
     use client::response::FromResponse;
     use super::Expiring;
@@ -217,5 +218,16 @@ mod tests {
         let json = json::encode(&expiring).unwrap();
         let decoded = json::decode(&json).unwrap();
         assert_eq!(expiring, decoded);
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let original = Expiring {
+            refresh_token: String::from("foo"),
+            expires: UTC::now().with_nanosecond(0).unwrap(),
+        };
+        let serialized = serde_json::to_value(&original);
+        let deserialized = serde_json::from_value(serialized).unwrap();
+        assert_eq!(original, deserialized);
     }
 }

--- a/src/token/statik.rs
+++ b/src/token/statik.rs
@@ -39,6 +39,7 @@ impl Deserialize for Static {
 #[cfg(test)]
 mod tests {
     use rustc_serialize::json::Json;
+    use serde_json;
 
     use client::response::{FromResponse, ParseError};
     use super::Static;
@@ -56,5 +57,13 @@ mod tests {
             ParseError::UnexpectedField("expires_in"),
             Static::from_response(&json).unwrap_err()
         );
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let original = Static;
+        let serialized = serde_json::to_value(&original);
+        let deserialized = serde_json::from_value(serialized).unwrap();
+        assert_eq!(original, deserialized);
     }
 }

--- a/src/token/statik.rs
+++ b/src/token/statik.rs
@@ -1,4 +1,6 @@
 use rustc_serialize::json::Json;
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
+use serde::de::impls::UnitVisitor;
 
 use super::Lifetime;
 use client::response::{FromResponse, ParseError, JsonHelper};
@@ -18,6 +20,19 @@ impl FromResponse for Static {
             return Err(ParseError::UnexpectedField("expires_in"));
         }
         Ok(Static)
+    }
+}
+
+impl Serialize for Static {
+    fn serialize<S: Serializer>(&self, serializer: &mut S) -> Result<(), S::Error> {
+        serializer.visit_unit_struct("Static")
+    }
+}
+
+impl Deserialize for Static {
+    fn deserialize<D: Deserializer>(deserializer: &mut D) -> Result<Self, D::Error> {
+        deserializer.visit_unit_struct("Static", UnitVisitor)
+            .and(Ok(Static))
     }
 }
 


### PR DESCRIPTION
Fixes #2.

Went with manual implementation to avoid the awkwardness of getting Serde's code generation to work on both stable and nightly.