### PR TITLE
Client::new() accepts different types

### DIFF
--- a/examples/github.rs
+++ b/examples/github.rs
@@ -9,9 +9,8 @@ fn main() {
     let client = Client::<GitHub>::new(
         Default::default(),
         "01774654cd9a6051e478",
-        "9f14d16d95d605e715ec1a9aecec220d2565fd5c",
-        Some("https://cmcenroe.me/oauth2-paste/")
-    );
+        "9f14d16d95d605e715ec1a9aecec220d2565fd5c"
+    ).redirect_uri("https://cmcenroe.me/oauth2-paste/");
 
     let auth_uri = client.auth_uri(Some("user"), None).unwrap();
     println!("{}", auth_uri);

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -9,9 +9,8 @@ fn main() {
     let client = Client::<Google>::new(
         Default::default(),
         "143225766783-ip2d9qv6sdr37276t77luk6f7bhd6bj5.apps.googleusercontent.com",
-        "3kZ5WomzHFlN2f_XbhkyPd3o",
-        Some("urn:ietf:wg:oauth:2.0:oob")
-    );
+        "3kZ5WomzHFlN2f_XbhkyPd3o"
+    ).redirect_uri("urn:ietf:wg:oauth:2.0:oob");
 
     let auth_uri = client.auth_uri(Some("https://www.googleapis.com/auth/userinfo.email"), None)
         .unwrap();

--- a/examples/imgur.rs
+++ b/examples/imgur.rs
@@ -10,8 +10,7 @@ fn main() {
         Default::default(),
         "505c8ca804230e0",
         "c898d8cf28404102752b2119a3a1c6aab49899c8",
-        Some("https://cmcenroe.me/oauth2-paste/")
-    );
+    ).redirect_uri("https://cmcenroe.me/oauth2-paste/");
 
     let auth_uri = client.auth_uri(None, None).unwrap();
     println!("{}", auth_uri);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -48,27 +48,27 @@ impl<P: Provider> Client<P> {
     /// let client = Client::<Google>::new(
     ///     Default::default(),
     ///     "CLIENT_ID",
-    ///     "CLIENT_SECRET",
-    ///     Some("urn:ietf:wg:oauth:2.0:oob")
-    /// );
+    ///     "CLIENT_SECRET"
+    /// ).redirect_uri("urn:ietf:wg:oauth:2.0:oob");
     /// ```
-    pub fn new<C, S, R>(
+    pub fn new<C, S>(
         http_client: hyper::Client,
         client_id: C,
         client_secret: S,
-        redirect_uri: Option<R>
-    ) -> Self where
-            C: Into<String>,
-            S: Into<String>,
-            R: Into<String> {
-
+    ) -> Self where C: Into<String>, S: Into<String> {
         Client {
             http_client: http_client,
             client_id: client_id.into(),
             client_secret: client_secret.into(),
-            redirect_uri: redirect_uri.map(Into::into),
+            redirect_uri: None,
             provider: PhantomData,
         }
+    }
+
+    /// Set redirect URI
+    pub fn redirect_uri<S: Into<String>>(mut self, redirect_uri: S) -> Self {
+        self.redirect_uri = Some(redirect_uri.into());
+        self
     }
 
     /// Returns an authorization endpoint URI to direct the user to.
@@ -84,9 +84,8 @@ impl<P: Provider> Client<P> {
     /// let client = Client::<Google>::new(
     ///     Default::default(),
     ///     "CLIENT_ID",
-    ///     "CLIENT_SECRET",
-    ///     Some("urn:ietf:wg:oauth:2.0:oob")
-    /// );
+    ///     "CLIENT_SECRET"
+    /// ).redirect_uri("urn:ietf:wg:oauth:2.0:oob");
     ///
     /// let auth_uri = client.auth_uri(
     ///     Some("https://www.googleapis.com/auth/userinfo.email"),
@@ -217,7 +216,7 @@ mod tests {
 
     #[test]
     fn auth_uri() {
-        let client = Client::<Test>::new(Default::default(), "foo", "bar", None);
+        let client = Client::<Test>::new(Default::default(), "foo", "bar");
         assert_eq!(
             "http://example.com/oauth2/auth?response_type=code&client_id=foo",
             client.auth_uri(None, None).unwrap()
@@ -230,8 +229,7 @@ mod tests {
             Default::default(),
             "foo",
             "bar",
-            Some("http://example.com/oauth2/callback")
-        );
+        ).redirect_uri("http://example.com/oauth2/callback");
         assert_eq!(
             "http://example.com/oauth2/auth?response_type=code&client_id=foo&redirect_uri=http%3A%2F%2Fexample.com%2Foauth2%2Fcallback",
             client.auth_uri(None, None).unwrap()
@@ -240,7 +238,7 @@ mod tests {
 
     #[test]
     fn auth_uri_with_scope() {
-        let client = Client::<Test>::new(Default::default(), "foo", "bar", None);
+        let client = Client::<Test>::new(Default::default(), "foo", "bar");
         assert_eq!(
             "http://example.com/oauth2/auth?response_type=code&client_id=foo&scope=baz",
             client.auth_uri(Some("baz"), None).unwrap()
@@ -249,7 +247,7 @@ mod tests {
 
     #[test]
     fn auth_uri_with_state() {
-        let client = Client::<Test>::new(Default::default(), "foo", "bar", None);
+        let client = Client::<Test>::new(Default::default(), "foo", "bar");
         assert_eq!(
             "http://example.com/oauth2/auth?response_type=code&client_id=foo&state=baz",
             client.auth_uri(None, Some("baz")).unwrap()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -52,12 +52,16 @@ impl<P: Provider> Client<P> {
     ///     Some("urn:ietf:wg:oauth:2.0:oob")
     /// );
     /// ```
-    pub fn new<S>(
+    pub fn new<C, S, R>(
         http_client: hyper::Client,
-        client_id: S,
+        client_id: C,
         client_secret: S,
-        redirect_uri: Option<S>
-    ) -> Self where S: Into<String> {
+        redirect_uri: Option<R>
+    ) -> Self where
+            C: Into<String>,
+            S: Into<String>,
+            R: Into<String> {
+
         Client {
             http_client: http_client,
             client_id: client_id.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,8 @@
 //! let client = Client::<Google>::new(
 //!     Default::default(),
 //!     "client_id",
-//!     "client_secret",
-//!     Some("redirect_uri")
-//! );
+//!     "client_secret"
+//! ).redirect_uri("redirect_uri");
 //! ```
 //!
 //! ### Constructing an authorization URI
@@ -45,7 +44,7 @@
 //! ```
 //! # use inth_oauth2::Client;
 //! # use inth_oauth2::provider::Google;
-//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let client = Client::<Google>::new(Default::default(), "", "");
 //! let auth_uri = client.auth_uri(Some("scope"), Some("state")).unwrap();
 //! println!("Authorize the application by clicking on the link: {}", auth_uri);
 //! ```
@@ -56,7 +55,7 @@
 //! use std::io;
 //! use inth_oauth2::{Client, Token};
 //! # use inth_oauth2::provider::Google;
-//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let client = Client::<Google>::new(Default::default(), "", "");
 //!
 //! let mut code = String::new();
 //! io::stdin().read_line(&mut code).unwrap();
@@ -70,7 +69,7 @@
 //! ```no_run
 //! # use inth_oauth2::Client;
 //! # use inth_oauth2::provider::Google;
-//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let client = Client::<Google>::new(Default::default(), "", "");
 //! # let token = client.request_token("").unwrap();
 //! let token = client.refresh_token(token, None).unwrap();
 //! ```
@@ -80,7 +79,7 @@
 //! ```no_run
 //! # use inth_oauth2::Client;
 //! # use inth_oauth2::provider::Google;
-//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let client = Client::<Google>::new(Default::default(), "", "");
 //! # let mut token = client.request_token("").unwrap();
 //! // Refresh token only if it has expired.
 //! token = client.ensure_token(token).unwrap();
@@ -98,7 +97,7 @@
 //! use hyper::header::Authorization;
 //!
 //! # fn main() {
-//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let client = Client::<Google>::new(Default::default(), "", "");
 //! # let token = client.request_token("").unwrap();
 //! let client = hyper::Client::new();
 //! let request = client.get("https://example.com/resource")
@@ -118,7 +117,7 @@
 //! # use inth_oauth2::provider::Google;
 //! use rustc_serialize::json;
 //! # fn main() {
-//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let client = Client::<Google>::new(Default::default(), "", "");
 //! # let token = client.request_token("").unwrap();
 //! let json = json::encode(&token).unwrap();
 //! # }
@@ -130,7 +129,7 @@
 //! # use inth_oauth2::Client;
 //! # use inth_oauth2::provider::Google;
 //! # fn main() {
-//! # let client = Client::<Google>::new(Default::default(), "", "", None);
+//! # let client = Client::<Google>::new(Default::default(), "", "");
 //! # let token = client.request_token("").unwrap();
 //! let json = serde_json::to_string(&token).unwrap();
 //! # }

--- a/tests/auth_uri.rs
+++ b/tests/auth_uri.rs
@@ -16,8 +16,7 @@ fn google_auth_uri_ok() {
         Default::default(),
         "143225766783-ip2d9qv6sdr37276t77luk6f7bhd6bj5.apps.googleusercontent.com",
         "",
-        Some("urn:ietf:wg:oauth:2.0:oob")
-    );
+    ).redirect_uri("urn:ietf:wg:oauth:2.0:oob");
     let auth_uri = client.auth_uri(
         Some("https://www.googleapis.com/auth/userinfo.email"),
         Some("state")
@@ -30,9 +29,8 @@ fn github_auth_uri_ok() {
     let client = Client::<GitHub>::new(
         Default::default(),
         "01774654cd9a6051e478",
-        "",
-        Some("https://cmcenroe.me/oauth2-paste/")
-    );
+        ""
+    ).redirect_uri("https://cmcenroe.me/oauth2-paste/");
     let auth_uri = client.auth_uri(Some("user"), Some("state")).unwrap();
     assert_get_uri_ok(&auth_uri);
 }
@@ -42,9 +40,8 @@ fn imgur_auth_uri_ok() {
     let client = Client::<Imgur>::new(
         Default::default(),
         "505c8ca804230e0",
-        "",
-        Some("https://cmcenroe.me/oauth2-paste/")
-    );
+        ""
+    ).redirect_uri("https://cmcenroe.me/oauth2-paste/");
     let auth_uri = client.auth_uri(None, Some("state")).unwrap();
     assert_get_uri_ok(&auth_uri);
 }

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -61,8 +61,7 @@ macro_rules! mock_client {
         Client::<$p>::new(
             hyper::Client::with_connector(<$c>::default()),
             "client_id",
-            "client_secret",
-            None
+            "client_secret"
         )
     }
 }


### PR DESCRIPTION
The `Client::new()` method accepts three arguments, convertible to `String`, but all of them must be of the same type `S`, so one can't pass `&str`, `String` and `&String` at the same time.

This patch makes sure a library user can use different types for `Client::new()` arguments, improving API ergonomics.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/programble/inth-oauth2/7)
<!-- Reviewable:end -->
