### PR TITLE
Support Dynamic Providers

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -27,11 +27,12 @@ pub struct Client<P: Provider> {
     /// Redirect URI.
     pub redirect_uri: Option<String>,
 
-    provider: P,
+    /// The provider.
+    pub provider: P,
 }
 
-impl<P: Provider> Client<P> {
-    /// Creates a client.
+impl<P: Provider + Default> Client<P> {
+     /// Creates a client.
     ///
     /// # Examples
     ///
@@ -48,7 +49,9 @@ impl<P: Provider> Client<P> {
     pub fn new(client_id: String, client_secret: String, redirect_uri: Option<String>) -> Self {
         Client::with_provider(client_id, client_secret,  P::default(), redirect_uri)
     }
+}
 
+impl<P: Provider> Client<P> {
     /// Creates a client with a given Provider. Use when the provider needs non-default Initialization.
     pub fn with_provider(
             client_id: String, 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -46,11 +46,21 @@ impl<P: Provider> Client<P> {
     /// );
     /// ```
     pub fn new(client_id: String, client_secret: String, redirect_uri: Option<String>) -> Self {
+        Client::with_provider(client_id, client_secret,  P::default(), redirect_uri)
+    }
+
+    /// Creates a client with a given Provider. Use when the provider needs non-default Initialization.
+    pub fn with_provider(
+            client_id: String, 
+            client_secret: String, 
+            provider: P, 
+            redirect_uri: Option<String>
+    ) -> Self {
         Client {
-            client_id: client_id,
-            client_secret: client_secret,
-            redirect_uri: redirect_uri,
-            provider: P::default(),
+            client_id,
+            client_secret,
+            redirect_uri,
+            provider
         }
     }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -3,7 +3,7 @@
 use token::{Token, Lifetime, Bearer, Static, Refresh};
 
 /// OAuth 2.0 providers.
-pub trait Provider: Default {
+pub trait Provider {
     /// The lifetime of tokens issued by the provider.
     type Lifetime: Lifetime;
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -3,7 +3,7 @@
 use token::{Token, Lifetime, Bearer, Static, Refresh};
 
 /// OAuth 2.0 providers.
-pub trait Provider {
+pub trait Provider: Default {
     /// The lifetime of tokens issued by the provider.
     type Lifetime: Lifetime;
 
@@ -15,14 +15,14 @@ pub trait Provider {
     /// See [RFC 6749, section 3.1](http://tools.ietf.org/html/rfc6749#section-3.1).
     ///
     /// Note: likely to become an associated constant.
-    fn auth_uri() -> &'static str;
+    fn auth_uri(&self) -> &str;
 
     /// The token endpoint URI.
     ///
     /// See [RFC 6749, section 3.2](http://tools.ietf.org/html/rfc6749#section-3.2).
     ///
     /// Note: likely to become an associated constant.
-    fn token_uri() -> &'static str;
+    fn token_uri(&self) -> &str;
 
     /// Provider requires credentials via request body.
     ///
@@ -62,49 +62,49 @@ pub mod google {
     ///
     /// See [Using OAuth 2.0 for Web Server
     /// Applications](https://developers.google.com/identity/protocols/OAuth2WebServer).
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
     pub struct Web;
     impl Provider for Web {
         type Lifetime = Expiring;
         type Token = Bearer<Expiring>;
-        fn auth_uri() -> &'static str { "https://accounts.google.com/o/oauth2/v2/auth" }
-        fn token_uri() -> &'static str { "https://www.googleapis.com/oauth2/v4/token" }
+        fn auth_uri(&self) -> &'static str { "https://accounts.google.com/o/oauth2/v2/auth" }
+        fn token_uri(&self) -> &'static str { "https://www.googleapis.com/oauth2/v4/token" }
     }
 
     /// Google OAuth 2.0 provider for installed applications.
     ///
     /// See [Using OAuth 2.0 for Installed
     /// Applications](https://developers.google.com/identity/protocols/OAuth2InstalledApp).
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
     pub struct Installed;
     impl Provider for Installed {
         type Lifetime = Refresh;
         type Token = Bearer<Refresh>;
-        fn auth_uri() -> &'static str { "https://accounts.google.com/o/oauth2/v2/auth" }
-        fn token_uri() -> &'static str { "https://www.googleapis.com/oauth2/v4/token" }
+        fn auth_uri(&self) -> &'static str { "https://accounts.google.com/o/oauth2/v2/auth" }
+        fn token_uri(&self) -> &'static str { "https://www.googleapis.com/oauth2/v4/token" }
     }
 }
 
 /// GitHub OAuth 2.0 provider.
 ///
 /// See [OAuth, GitHub Developer Guide](https://developer.github.com/v3/oauth/).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GitHub;
 impl Provider for GitHub {
     type Lifetime = Static;
     type Token = Bearer<Static>;
-    fn auth_uri() -> &'static str { "https://github.com/login/oauth/authorize" }
-    fn token_uri() -> &'static str { "https://github.com/login/oauth/access_token" }
+    fn auth_uri(&self) -> &'static str { "https://github.com/login/oauth/authorize" }
+    fn token_uri(&self) -> &'static str { "https://github.com/login/oauth/access_token" }
 }
 
 /// Imgur OAuth 2.0 provider.
 ///
 /// See [OAuth 2.0, Imgur](https://api.imgur.com/oauth2).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Imgur;
 impl Provider for Imgur {
     type Lifetime = Refresh;
     type Token = Bearer<Refresh>;
-    fn auth_uri() -> &'static str { "https://api.imgur.com/oauth2/authorize" }
-    fn token_uri() -> &'static str { "https://api.imgur.com/oauth2/token" }
+    fn auth_uri(&self) -> &'static str { "https://api.imgur.com/oauth2/authorize" }
+    fn token_uri(&self) -> &'static str { "https://api.imgur.com/oauth2/token" }
 }

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -12,28 +12,31 @@ mod provider {
     use inth_oauth2::token::{Bearer, Static, Expiring, Refresh};
     use inth_oauth2::provider::Provider;
 
+    #[derive(Default)]
     pub struct BearerStatic;
     impl Provider for BearerStatic {
         type Lifetime = Static;
         type Token = Bearer<Static>;
-        fn auth_uri() -> &'static str { "https://example.com/oauth/auth" }
-        fn token_uri() -> &'static str { "https://example.com/oauth/token" }
+        fn auth_uri(&self) -> &'static str { "https://example.com/oauth/auth" }
+        fn token_uri(&self) -> &'static str { "https://example.com/oauth/token" }
     }
 
+    #[derive(Default)]
     pub struct BearerExpiring;
     impl Provider for BearerExpiring {
         type Lifetime = Expiring;
         type Token = Bearer<Expiring>;
-        fn auth_uri() -> &'static str { "https://example.com/oauth/auth" }
-        fn token_uri() -> &'static str { "https://example.com/oauth/token" }
+        fn auth_uri(&self) -> &'static str { "https://example.com/oauth/auth" }
+        fn token_uri(&self) -> &'static str { "https://example.com/oauth/token" }
     }
 
+    #[derive(Default)]
     pub struct BearerRefresh;
     impl Provider for BearerRefresh {
         type Lifetime = Refresh;
         type Token = Bearer<Refresh>;
-        fn auth_uri() -> &'static str { "https://example.com/oauth/auth" }
-        fn token_uri() -> &'static str { "https://example.com/oauth/token" }
+        fn auth_uri(&self) -> &'static str { "https://example.com/oauth/auth" }
+        fn token_uri(&self) -> &'static str { "https://example.com/oauth/token" }
     }
 }
 


### PR DESCRIPTION
While [Oauth Discovery is still a draft](https://tools.ietf.org/html/draft-ietf-oauth-discovery) OpenID Connect Discovery is 1.0 stable. Given the current format of the Provider trait there is no way to "cleanly" provide runtime derived auth / token uris. This leads to some undesirable workarounds when trying to implement Discovery, such as [static mut leaky strings](https://gitlab.com/zanny/hyper-openid/blob/unsafe/src/provider.rs#L22).

In these patches we make the auth and token functions take &self so dynamic impls can carry the strings around with them. This means Client needs a concrete Provider, and the easiest way to not break the public API is to just make Providers derive default. Then we add with_provider to let users with Dynamic Providers supply their own constructed providers (with dynamic uris).

An alternative impl is to not derive default, keep only one client constructor, but make it take a provider as an argument. That adds an extra useless variable for most users though.